### PR TITLE
RedHat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This role provides the following:
 Supports the following Operating Systems:
 * CentOS 6
 * CentOS 7
+* RedHat 6
+* RedHat 7
 * OracleLinux 6
 * OracleLinux 7
 * Ubuntu 12.04

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,10 @@ galaxy_info:
     versions:
     - 6
     - 7
+  - name: RedHat
+    versions:
+    - 6
+    - 7
   - name: Fedora
     versions:
     - 22
@@ -31,5 +35,6 @@ galaxy_info:
   - docker
   - ubuntu
   - centos
+  - redhat
   - debian
 dependencies: []

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -1,4 +1,9 @@
 ---
+- include_vars: "{{ item }"
+  with_first_found:
+   - "{{ ansible_distribution }}.yml"
+   - "{{ ansible_os_family }}.yml"
+   - "default.yml"
 - name: YUM | Disable UEK R3 for Oracle Linux
   yum_repository:
     name: ol7_UEKR3
@@ -23,7 +28,7 @@
   yum_repository:
     name: dockerrepo
     description: Docker Repository
-    baseurl: "https://yum.dockerproject.org/repo/main/{{ ansible_distribution|lower}}/{{ ansible_distribution_major_version }}/"
+    baseurl: "https://yum.dockerproject.org/repo/main/{{ docker_package_directory }}/{{ ansible_distribution_major_version }}/"
     enabled: 1
     gpgcheck: 1
     gpgkey: https://yum.dockerproject.org/gpg

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -1,9 +1,10 @@
 ---
 - include_vars: "{{ item }"
   with_first_found:
-   - "{{ ansible_distribution }}.yml"
-   - "{{ ansible_os_family }}.yml"
-   - "default.yml"
+    - "{{ ansible_distribution }}.yml"
+    - "{{ ansible_os_family }}.yml"
+    - "default.yml"
+
 - name: YUM | Disable UEK R3 for Oracle Linux
   yum_repository:
     name: ol7_UEKR3

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,1 @@
+docker_package_directory: "centos"

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,0 +1,1 @@
+docker_package_directory: "{{ ansible_distribution | lower }}"


### PR DESCRIPTION
The docker repo for RedHat7 lives at:
https://yum.dockerproject.org/repo/main/centos/7/

The changes in this PR accommodate for that inconsistency in dockers repository naming structure.
