### PR TITLE
Extensive GPG verification for DNF

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for avinetworks.docker
+docker_gpg_fprint: 58118E89F3A912897C070ADBF76221572C52609D

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,9 @@
 ---
 # defaults file for avinetworks.docker
 docker_gpg_fprint: 58118E89F3A912897C070ADBF76221572C52609D
+
+
+# Docker Yum repository gpg file
+docker_yum_gpg_url: https://yum.dockerproject.org/gpg
+
+docker_yum_gpg_local: /etc/pki/dockerproject.gpg

--- a/tasks/apt.yml
+++ b/tasks/apt.yml
@@ -8,7 +8,7 @@
 - name: APT | Add Docker GPG Key
   apt_key:
     keyserver: hkp://p80.pool.sks-keyservers.net:80
-    id: 58118E89F3A912897C070ADBF76221572C52609D
+    id: "{{ docker_gpg_fprint }}"
 
 #Docker’s APT repository contains Docker 1.7.1 and higher.
 - name: APT | Configure Docker repository

--- a/tasks/dnf.yml
+++ b/tasks/dnf.yml
@@ -1,4 +1,21 @@
 ---
+
+- name: DNF | Loadup GPG value
+  set_fact:
+    docker_gpg_key: "{{ lookup('pipe', 'curl -s '+docker_yum_gpg_url) }}"
+  become: no
+
+- name: DNF | Verify Docker GPG value
+  shell: echo '{{ docker_gpg_key }}' | gpg2 | grep -q {{ docker_gpg_fprint }}
+  args:
+    executable: /bin/bash
+  register: register_gpg_verify
+
+- name: DNF | Drop GPG value into local file
+  copy:
+    content: "{{ docker_gpg_key }}"
+    dest: "{{ docker_yum_gpg_local }}"
+
 - name: DNF | Configure Docker repository
   yum_repository:
     name: dockerrepo
@@ -6,7 +23,7 @@
     baseurl: "https://yum.dockerproject.org/repo/main/{{ ansible_distribution|lower}}/{{ ansible_distribution_major_version }}/"
     enabled: 1
     gpgcheck: 1
-    gpgkey: https://yum.dockerproject.org/gpg
+    gpgkey: "file://{{ docker_yum_gpg_local }}"
 
 - name: DNF | Remove Old Docker
   dnf: name=docker state=absent

--- a/tasks/yum.yml
+++ b/tasks/yum.yml
@@ -30,7 +30,7 @@
         baseurl: "https://yum.dockerproject.org/repo/main/{{ docker_package_directory }}/{{ ansible_distribution_major_version }}/"
         enabled: 1
         gpgcheck: 1
-        gpgkey: https://yum.dockerproject.org/gpg
+        gpgkey: "{{ docker_yum_gpg_url }}"
     - name: YUM | Remove previous docker-io
       yum: name=docker-io state=absent
     - name: YUM | Install Docker Application


### PR DESCRIPTION
Based on known GPG fingerprint value, download the docker GPG key,
verify the fingerprint matches, drop that onto the filesystem, then
point the repo to that file.

This is a round-about way to recreate the functionality that `apt_key` is
doing. Unfortunately `rpm_key` doesn't allow adding a key via fingerprint
like the apt_key module. Ultimately upstream rpm_key should be upgraded
but this is the short-term fix.