### PR TITLE
Fixes installation of LVM2 with APT

### DIFF
--- a/tasks/storage_drivers/devicemapper.yml
+++ b/tasks/storage_drivers/devicemapper.yml
@@ -9,7 +9,7 @@
 
 - name: Docker | Storage Driver | devicemapper | Install LVM2 | APT
   apt: name=lvm2 state=present
-  when: ansible_pkg_mgr == 'dnf'
+  when: ansible_pkg_mgr == 'apt'
 
 - name: Docker | Storage Driver | devicemapper | Configure logical volume group
   lvg: vg=docker pvs="{{ docker_block_device }}"


### PR DESCRIPTION
Hi!

I found a typo that could result in LVM2 not being installed on APT based systems when configuring devicemapper storage.

This will probably fail on Fedora too.