### PR TITLE
Update overlay2.yml

### DIFF
--- a/tasks/storage_drivers/overlay2.yml
+++ b/tasks/storage_drivers/overlay2.yml
@@ -1,13 +1,13 @@
 ---
 - name: Docker | Storage Driver | overlay2 | Check kernel version for 4.0.0
   assert:
-    that: "{{ ansible_kernel | version_compare('4.0.0', '>=')}}"
+    that: "{{ ansible_kernel is version_compare('4.0.0', '>=')}}"
     msg: "Please upgrade to kernel 4.0.0 or higher."
   when: ansible_os_family|lower != "redhat"
 
 - name: Docker | Storage Driver | overlay2 | Check kernel version for 3.10.0-514
   assert:
-    that: "{{ ansible_kernel | version_compare('3.10.0-514', '>=')}}"
+    that: "{{ ansible_kernel is version_compare('3.10.0-514', '>=')}}"
     msg: "Please upgrade to kernel 3.10.0-514 or higher."
   when: ansible_os_family|lower == "redhat"
 

--- a/tasks/storage_drivers/overlay2.yml
+++ b/tasks/storage_drivers/overlay2.yml
@@ -1,13 +1,13 @@
 ---
 - name: Docker | Storage Driver | overlay2 | Check kernel version for 4.0.0
   assert:
-    that: "{{ ansible_kernel is version_compare('4.0.0', '>=')}}"
+    that: "{{ ansible_kernel is version('4.0.0', '>=')}}"
     msg: "Please upgrade to kernel 4.0.0 or higher."
   when: ansible_os_family|lower != "redhat"
 
 - name: Docker | Storage Driver | overlay2 | Check kernel version for 3.10.0-514
   assert:
-    that: "{{ ansible_kernel is version_compare('3.10.0-514', '>=')}}"
+    that: "{{ ansible_kernel is version('3.10.0-514', '>=')}}"
     msg: "Please upgrade to kernel 3.10.0-514 or higher."
   when: ansible_os_family|lower == "redhat"
 


### PR DESCRIPTION
this results in following error when running latest ansible version:
"template error while templating string: no filter named 'version_compare'."

this has been reported in other threads - see reference here with suggested simple fix:
https://github.com/geerlingguy/ansible-role-git/commit/c78b87a69c4497801e0f21c84e7a608ae98ecd40

and here:
http://guishunda.com/github_/ansible/ansible/issues/64174
