### PR TITLE
[fix] Fixed boolean length check and version_compare to version filter

### DIFF
--- a/tasks/deploy_config.yml
+++ b/tasks/deploy_config.yml
@@ -10,7 +10,7 @@
 - name: Docker | Deploy Config | Set the Docker configuration
   set_fact:
     docker_config: "{{ docker_config|combine({ item.key: item.value }) }}"
-  when: item.value | length > 0
+  when: item.value | string | length > 0
   with_dict: "{{ docker_options }}"
 
 - name: Docker | Deploy Config | Deploy /etc/docker/daemon.json

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for avinetworks.docker
 - name: Check ansible version
   when:
-    - ansible_version.full is version_compare('2.4', '<')
+    - ansible_version.full is version('2.4', '<')
   debug:
     msg: >-
       "This role works best with ansible version 2.4 or greater.

--- a/tasks/storage_drivers/overlay2.yml
+++ b/tasks/storage_drivers/overlay2.yml
@@ -1,13 +1,13 @@
 ---
 - name: Docker | Storage Driver | overlay2 | Check kernel version for 4.0.0
   assert:
-    that: "{{ ansible_kernel | version_compare('4.0.0', '>=')}}"
+    that: "{{ ansible_kernel is version('4.0.0', '>=')}}"
     msg: "Please upgrade to kernel 4.0.0 or higher."
   when: ansible_os_family|lower != "redhat"
 
 - name: Docker | Storage Driver | overlay2 | Check kernel version for 3.10.0-514
   assert:
-    that: "{{ ansible_kernel | version_compare('3.10.0-514', '>=')}}"
+    that: "{{ ansible_kernel is version('3.10.0-514', '>=')}}"
     msg: "Please upgrade to kernel 3.10.0-514 or higher."
   when: ansible_os_family|lower == "redhat"
 


### PR DESCRIPTION
Fixed some errors of role due to depricated filter in ansible > 2.9 and checking the length of boolean variable (in case of live_restore: true)