### PR TITLE
Add no-new-privileges option for daemon.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ For more information about the variables many can be found https://docs.docker.c
 | `docker_max_concurrent_downloads` | No | `Undefined` | Set the max concurrent downloads for each pull |
 | `docker_max_concurrent_uploads` | No | `Undefined` | Set the max concurrent uploads for each push |
 | `docker_mtu` | No | `Undefined` | Set the containers network MTU |
+| `docker_no_new_privileges` | No | `Undefined` | Set no-new-privileges by default for new containers |
 | `docker_oom_score_adjust` | No | `Undefined` | Set the oom_score_adj for the daemon |
 | `docker_pidfile` | No | `Undefined` | Path to use for daemon PID file |
 | `docker_raw_logs` | No | `Undefined` | Full timestamps without ANSI coloring |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,7 @@ docker_options:
   max-concurrent-downloads: "{{ docker_max_concurrent_downloads | default(None) }}"
   max-concurrent-uploads: "{{ docker_max_concurrent_uploads | default(None) }}"
   mtu: "{{ docker_mtu | default(None) }}"
+  no-new-privileges: "{{ docker_no_new_privileges | default(None) }}"
   oom-score-adjust: "{{ docker_oom_score_adjust | default(None) }}"
   pidfile: "{{ docker_pidfile | default(None) }}"
   raw-logs: "{{ docker_raw_logs | default(None) }}"


### PR DESCRIPTION
As described here https://docs.docker.com/engine/reference/commandline/dockerd/#daemon-configuration-file

This option is required to pass docker bench security (see https://github.com/docker/docker-bench-security)